### PR TITLE
Add lint script and apply ruff formatting

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,6 +58,17 @@ sshaman/
 └── requirements.txt
 ```
 
+## Linting
+
+Run `./scripts/lint.sh` after every non-trivial edit session (new files, refactors, dependency changes):
+
+```bash
+./scripts/lint.sh          # check only
+./scripts/lint.sh --fix    # apply safe auto-fixes
+```
+
+This runs `ruff check` (error/style rules) followed by `ruff format --check`. Address all reported errors before committing — the CI pipeline enforces a clean ruff run. Never use `# noqa` to silence a rule without a comment explaining why.
+
 ## Testing
 
 - Use `tmp_path` pytest fixtures — never write to real `~/.ssh/` in tests.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -81,6 +81,8 @@
         "/^source \\.venv/bin/activate && python -m pytest tests/ -q --tb=line 2>&1 \\| tail -30$/": {
             "approve": true,
             "matchCommandLine": true
-        }
+        },
+        ".venv/bin/ruff": true,
+        "ruff": true
     }
 }

--- a/backend/host_entry.py
+++ b/backend/host_entry.py
@@ -207,9 +207,7 @@ class HostEntry(BaseModel):
                 stripped = line.strip()
                 lower = stripped.lower()
                 if not lower.startswith("host ") and lower != "host":
-                    raise ValueError(
-                        f"Expected 'Host <name>' line, got: {line!r}"
-                    )
+                    raise ValueError(f"Expected 'Host <name>' line, got: {line!r}")
                 host_name = stripped[5:].strip()  # everything after "Host "
                 host_line_found = True
                 continue

--- a/backend/manager.py
+++ b/backend/manager.py
@@ -62,7 +62,8 @@ class SSHManager:
 
         q = filter.lower()
         return [
-            h for h in hosts
+            h
+            for h in hosts
             if q in h.name.lower()
             or q in h.hostname.lower()
             or (h.user and q in h.user.lower())

--- a/backend/migrate.py
+++ b/backend/migrate.py
@@ -112,16 +112,16 @@ def convert_json_to_host_entry(
     except ValueError:
         comment_text = "# Migrated by SSHaMan"
 
-    local_forwards: list[str] = [
-        fp for fp in (data.get("forward_ports") or []) if fp
-    ]
+    local_forwards: list[str] = [fp for fp in (data.get("forward_ports") or []) if fp]
 
     entry = HostEntry(
         name=alias,
         hostname=data["host"],
         user=data.get("user") or None,
         port=int(data.get("port", 22)),
-        identity_file=Path(data["identity_file"]) if data.get("identity_file") else None,
+        identity_file=Path(data["identity_file"])
+        if data.get("identity_file")
+        else None,
         local_forwards=local_forwards,
         comment=comment_text,
     )

--- a/backend/ssh_config.py
+++ b/backend/ssh_config.py
@@ -103,9 +103,7 @@ class SSHConfigManager:
         """
         if not self.config_d.exists():
             return []
-        return sorted(
-            p for p in self.config_d.iterdir() if p.is_file()
-        )
+        return sorted(p for p in self.config_d.iterdir() if p.is_file())
 
     def create_config_file(self, name: str) -> Path:
         """Create a new empty file in ``config.d/`` with correct permissions.
@@ -124,9 +122,7 @@ class SSHConfigManager:
         path = _validate_config_file_name(self.config_d, name)
 
         if path.exists():
-            raise SSHConfigError(
-                f"Config file already exists: {path}"
-            )
+            raise SSHConfigError(f"Config file already exists: {path}")
 
         path.touch()
         _set_permissions(path, _FILE_MODE)
@@ -143,9 +139,7 @@ class SSHConfigManager:
         """
         path = _validate_config_file_name(self.config_d, name)
         if not path.exists():
-            raise SSHConfigError(
-                f"Config file does not exist: {path}"
-            )
+            raise SSHConfigError(f"Config file does not exist: {path}")
         path.unlink()
 
     # ------------------------------------------------------------------
@@ -288,6 +282,7 @@ class SSHConfigManager:
 # Module-level parsing helpers
 # ---------------------------------------------------------------------------
 
+
 def _set_permissions(path: Path, mode: int) -> None:
     """Set ``mode`` on ``path`` if it differs from the current permissions.
 
@@ -324,9 +319,7 @@ def _validate_config_file_name(config_d: Path, name: str) -> Path:
             f"Config file name must not contain path separators or null bytes: {name!r}"
         )
     if name in (".", ".."):
-        raise SSHConfigError(
-            f"Config file name must not be '.' or '..': {name!r}"
-        )
+        raise SSHConfigError(f"Config file name must not be '.' or '..': {name!r}")
     return config_d / name
 
 
@@ -355,7 +348,9 @@ def _split_into_blocks(text: str, source_file: Path) -> list[HostEntry]:
         if not current_block:
             return
         try:
-            entry = HostEntry.from_ssh_config_block(current_block, source_file=source_file)
+            entry = HostEntry.from_ssh_config_block(
+                current_block, source_file=source_file
+            )
             entries.append(entry)
         except ValueError:
             pass  # Malformed blocks are skipped silently

--- a/cli/sshaman_cli.py
+++ b/cli/sshaman_cli.py
@@ -27,6 +27,7 @@ err_console = Console(stderr=True, style="bold red")
 # Root group
 # ---------------------------------------------------------------------------
 
+
 @click.group(invoke_without_command=True)
 @click.option(
     "--ssh-dir",
@@ -63,8 +64,11 @@ def cli(ctx: click.Context, ssh_dir: Optional[Path]) -> None:
 # list
 # ---------------------------------------------------------------------------
 
+
 @cli.command("list")
-@click.option("--filter", "-f", "pattern", default=None, help="Filter by name, hostname, or user.")
+@click.option(
+    "--filter", "-f", "pattern", default=None, help="Filter by name, hostname, or user."
+)
 @click.pass_context
 def list_hosts(ctx: click.Context, pattern: Optional[str]) -> None:
     """List all SSH hosts."""
@@ -98,6 +102,7 @@ def list_hosts(ctx: click.Context, pattern: Optional[str]) -> None:
 # show
 # ---------------------------------------------------------------------------
 
+
 @cli.command()
 @click.argument("host")
 @click.pass_context
@@ -128,12 +133,15 @@ def show(ctx: click.Context, host: str) -> None:
             lines.append(f"[bold]{k.capitalize()}:[/bold] {v}")
 
     source = entry.source_file.name if entry.source_file else "unknown"
-    console.print(Panel("\n".join(lines), title=f"[bold]{entry.name}[/bold]", subtitle=source))
+    console.print(
+        Panel("\n".join(lines), title=f"[bold]{entry.name}[/bold]", subtitle=source)
+    )
 
 
 # ---------------------------------------------------------------------------
 # add
 # ---------------------------------------------------------------------------
+
 
 @cli.command()
 @click.argument("name")
@@ -142,7 +150,10 @@ def show(ctx: click.Context, host: str) -> None:
 @click.option("--port", "-p", default=22, show_default=True, help="SSH port.")
 @click.option("--identity-file", "-i", default=None, help="Path to private key.")
 @click.option(
-    "--config-file", "-c", default="sshaman-hosts", show_default=True,
+    "--config-file",
+    "-c",
+    default="sshaman-hosts",
+    show_default=True,
     help="Target config.d filename.",
 )
 @click.pass_context
@@ -167,7 +178,9 @@ def add(
 
     try:
         mgr.add_host(entry, config_file=config_file)
-        console.print(f"[green]✓[/green] Added host [bold]{name}[/bold] to [dim]{config_file}[/dim].")
+        console.print(
+            f"[green]✓[/green] Added host [bold]{name}[/bold] to [dim]{config_file}[/dim]."
+        )
     except DuplicateHostError as exc:
         err_console.print(str(exc))
         ctx.exit(1)
@@ -176,6 +189,7 @@ def add(
 # ---------------------------------------------------------------------------
 # edit
 # ---------------------------------------------------------------------------
+
 
 @cli.command()
 @click.argument("host")
@@ -220,6 +234,7 @@ def edit(
 # remove
 # ---------------------------------------------------------------------------
 
+
 @cli.command()
 @click.argument("host")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")
@@ -243,6 +258,7 @@ def remove(ctx: click.Context, host: str, yes: bool) -> None:
 # connect
 # ---------------------------------------------------------------------------
 
+
 @cli.command()
 @click.argument("host")
 @click.pass_context
@@ -260,6 +276,7 @@ def connect(ctx: click.Context, host: str) -> None:
 # ---------------------------------------------------------------------------
 # sftp
 # ---------------------------------------------------------------------------
+
 
 @cli.command()
 @click.argument("host")
@@ -279,6 +296,7 @@ def sftp(ctx: click.Context, host: str) -> None:
 # search
 # ---------------------------------------------------------------------------
 
+
 @cli.command()
 @click.argument("pattern")
 @click.pass_context
@@ -290,6 +308,7 @@ def search(ctx: click.Context, pattern: str) -> None:
 # ---------------------------------------------------------------------------
 # config subgroup
 # ---------------------------------------------------------------------------
+
 
 @cli.group("config")
 def config_group() -> None:
@@ -313,7 +332,9 @@ def config_list(ctx: click.Context) -> None:
 
     all_hosts = mgr.list_hosts()
     for path in files:
-        count = sum(1 for h in all_hosts if h.source_file and h.source_file.name == path.name)
+        count = sum(
+            1 for h in all_hosts if h.source_file and h.source_file.name == path.name
+        )
         table.add_row(path.name, str(count))
 
     console.print(table)
@@ -379,6 +400,7 @@ def config_init(ctx: click.Context) -> None:
 # migrate
 # ---------------------------------------------------------------------------
 
+
 @cli.command()
 @click.option(
     "--source",
@@ -387,10 +409,14 @@ def config_init(ctx: click.Context) -> None:
     help="Path to legacy SSHaMan directory (default: ~/.config/sshaman).",
 )
 @click.option(
-    "--config-file", default="sshaman-migrated", show_default=True,
+    "--config-file",
+    default="sshaman-migrated",
+    show_default=True,
     help="Target config.d filename.",
 )
-@click.option("--dry-run", is_flag=True, help="Show what would be migrated without writing.")
+@click.option(
+    "--dry-run", is_flag=True, help="Show what would be migrated without writing."
+)
 @click.option("--force", is_flag=True, help="Overwrite existing target config file.")
 @click.pass_context
 def migrate(
@@ -436,13 +462,17 @@ def migrate(
         console.print(f"  [red]✗[/red] {path}: {err}")
 
     action = "Would write" if dry_run else "Wrote"
-    console.print(f"\n{action} [bold]{len(result.migrated)}[/bold] host(s) to [dim]{config_file}[/dim].")
+    console.print(
+        f"\n{action} [bold]{len(result.migrated)}[/bold] host(s) to [dim]{config_file}[/dim]."
+    )
 
     if dry_run:
         console.print("[dim]Run without --dry-run to apply.[/dim]")
 
     if result.source_cleanup_reminder:
-        console.print(f"\n[yellow]⚠ Security reminder:[/yellow] {result.source_cleanup_reminder}")
+        console.print(
+            f"\n[yellow]⚠ Security reminder:[/yellow] {result.source_cleanup_reminder}"
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover — entry point guard

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+include = ["backend*", "cli*", "tui*"]
+
 [project]
 name = "sshaman"
 version = "0.1.0"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Run ruff linting and (optionally) auto-fix safe issues.
+#
+# Usage:
+#   ./scripts/lint              # check only — non-zero exit if errors found
+#   ./scripts/lint --fix        # apply safe auto-fixes (ruff --fix)
+#   ./scripts/lint --unsafe-fix # apply safe + unsafe auto-fixes
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------------------
+# Parse flags
+# ---------------------------------------------------------------------------
+FIX_FLAG=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --fix)        FIX_FLAG="--fix" ;;
+    --unsafe-fix) FIX_FLAG="--fix --unsafe-fixes" ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      echo "Usage: $0 [--fix | --unsafe-fix]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Locate ruff — prefer the project venv so the version is pinned
+# ---------------------------------------------------------------------------
+RUFF=""
+if [[ -x "$REPO_ROOT/.venv/bin/ruff" ]]; then
+  RUFF="$REPO_ROOT/.venv/bin/ruff"
+elif command -v ruff &>/dev/null; then
+  RUFF="ruff"
+else
+  echo "ruff not found. Install it with: pip install ruff" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+echo "==> ruff check $FIX_FLAG ."
+# shellcheck disable=SC2086
+"$RUFF" check $FIX_FLAG .
+
+echo ""
+echo "==> ruff format --check ."
+"$RUFF" format --check .
+
+echo ""
+echo "All lint checks passed."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from backend.ssh_config import SSHConfigManager
 # SSH directory fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def ssh_dir(tmp_path: Path) -> Path:
     """Return a temporary ~/.ssh/ equivalent with config.d/ already created.
@@ -68,11 +69,7 @@ def sample_ssh_dir(ssh_dir: Path) -> Path:
 
     extra_hosts = ssh_dir / "config.d" / "extra-hosts"
     extra_hosts.write_text(
-        "Host jump-box\n"
-        "    HostName 10.0.0.1\n"
-        "    User ops\n"
-        "    Port 22\n"
-        "\n",
+        "Host jump-box\n    HostName 10.0.0.1\n    User ops\n    Port 22\n\n",
         encoding="utf-8",
     )
     extra_hosts.chmod(0o600)
@@ -83,6 +80,7 @@ def sample_ssh_dir(ssh_dir: Path) -> Path:
 # ---------------------------------------------------------------------------
 # Manager / config-manager fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def config_manager(sample_ssh_dir: Path) -> SSHConfigManager:
@@ -111,6 +109,7 @@ def empty_manager(ssh_dir: Path) -> SSHManager:
 # ---------------------------------------------------------------------------
 # Legacy JSON config fixtures (for migration tests)
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def legacy_config_dir(tmp_path: Path) -> Path:

--- a/tests/test_backend/test_host_entry.py
+++ b/tests/test_backend/test_host_entry.py
@@ -14,6 +14,7 @@ from backend.host_entry import HostEntry
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def minimal_entry(**kwargs) -> HostEntry:
     """Return a minimal valid HostEntry, merging any overrides."""
     defaults = {"name": "my-server", "hostname": "192.168.1.1"}
@@ -24,6 +25,7 @@ def minimal_entry(**kwargs) -> HostEntry:
 # ---------------------------------------------------------------------------
 # Construction / validation
 # ---------------------------------------------------------------------------
+
 
 class TestHostEntryConstruction:
     def test_minimal_fields(self):
@@ -62,8 +64,9 @@ class TestHostEntryConstruction:
 
     def test_extra_options_keys_lowercased(self):
         entry = HostEntry(
-            name="s", hostname="h",
-            extra_options={"UseKeychain": "yes", "IgnoreUnknown": "UseKeychain"}
+            name="s",
+            hostname="h",
+            extra_options={"UseKeychain": "yes", "IgnoreUnknown": "UseKeychain"},
         )
         assert "usekeychain" in entry.extra_options
         assert "ignoreunknown" in entry.extra_options
@@ -135,6 +138,7 @@ class TestHostEntryConstruction:
 # to_ssh_config serialisation
 # ---------------------------------------------------------------------------
 
+
 class TestToSshConfig:
     def test_minimal_serialisation(self):
         entry = HostEntry(name="srv", hostname="10.0.0.1")
@@ -178,7 +182,9 @@ class TestToSshConfig:
         assert "    LocalForward 8080 localhost:80" in entry.to_ssh_config()
 
     def test_multiple_local_forwards(self):
-        entry = HostEntry(name="s", hostname="h", local_forwards=["8080 h:80", "9090 h:90"])
+        entry = HostEntry(
+            name="s", hostname="h", local_forwards=["8080 h:80", "9090 h:90"]
+        )
         text = entry.to_ssh_config()
         assert "    LocalForward 8080 h:80" in text
         assert "    LocalForward 9090 h:90" in text
@@ -189,8 +195,9 @@ class TestToSshConfig:
 
     def test_extra_options_included(self):
         entry = HostEntry(
-            name="s", hostname="h",
-            extra_options={"usekeychain": "yes", "ignoreunknown": "UseKeychain"}
+            name="s",
+            hostname="h",
+            extra_options={"usekeychain": "yes", "ignoreunknown": "UseKeychain"},
         )
         text = entry.to_ssh_config()
         assert "Usekeychain yes" in text
@@ -220,6 +227,7 @@ class TestToSshConfig:
 # ---------------------------------------------------------------------------
 # from_ssh_config_block parsing
 # ---------------------------------------------------------------------------
+
 
 class TestFromSshConfigBlock:
     def test_minimal_block(self):
@@ -350,6 +358,7 @@ class TestFromSshConfigBlock:
 # ---------------------------------------------------------------------------
 # Round-trip
 # ---------------------------------------------------------------------------
+
 
 class TestRoundTrip:
     def test_minimal_round_trip(self):

--- a/tests/test_backend/test_manager.py
+++ b/tests/test_backend/test_manager.py
@@ -19,6 +19,7 @@ from backend.ssh_config import SSHConfigError
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def entry(name: str, hostname: str = "10.0.0.1", **kw) -> HostEntry:
     return HostEntry(name=name, hostname=hostname, **kw)
 
@@ -26,6 +27,7 @@ def entry(name: str, hostname: str = "10.0.0.1", **kw) -> HostEntry:
 # ---------------------------------------------------------------------------
 # list_hosts
 # ---------------------------------------------------------------------------
+
 
 class TestListHosts:
     def test_returns_all_hosts(self, manager: SSHManager):
@@ -70,6 +72,7 @@ class TestListHosts:
 # get_host
 # ---------------------------------------------------------------------------
 
+
 class TestGetHost:
     def test_returns_host_by_name(self, manager: SSHManager):
         host = manager.get_host("web-server")
@@ -90,13 +93,16 @@ class TestGetHost:
 # add_host
 # ---------------------------------------------------------------------------
 
+
 class TestAddHost:
     def test_adds_host_to_default_file(self, empty_manager: SSHManager, ssh_dir: Path):
         new = entry("newbie", "10.99.0.1")
         empty_manager.add_host(new)
         assert empty_manager.get_host("newbie") is not None
 
-    def test_adds_host_to_specified_file(self, empty_manager: SSHManager, ssh_dir: Path):
+    def test_adds_host_to_specified_file(
+        self, empty_manager: SSHManager, ssh_dir: Path
+    ):
         new = entry("srv", "10.0.0.5")
         empty_manager.add_host(new, config_file="my-hosts")
         path = ssh_dir / "config.d" / "my-hosts"
@@ -119,6 +125,7 @@ class TestAddHost:
 # ---------------------------------------------------------------------------
 # edit_host
 # ---------------------------------------------------------------------------
+
 
 class TestEditHost:
     def test_updates_hostname(self, manager: SSHManager):
@@ -149,6 +156,7 @@ class TestEditHost:
 # remove_host
 # ---------------------------------------------------------------------------
 
+
 class TestRemoveHost:
     def test_removes_host(self, manager: SSHManager):
         manager.remove_host("jump-box")
@@ -167,6 +175,7 @@ class TestRemoveHost:
 # ---------------------------------------------------------------------------
 # connect_command / sftp_command
 # ---------------------------------------------------------------------------
+
 
 class TestConnectCommand:
     def test_returns_ssh_alias_list(self, manager: SSHManager):
@@ -191,6 +200,7 @@ class TestSftpCommand:
 # ---------------------------------------------------------------------------
 # Config file management
 # ---------------------------------------------------------------------------
+
 
 class TestListConfigFiles:
     def test_returns_correct_files(self, manager: SSHManager, sample_ssh_dir: Path):
@@ -226,6 +236,7 @@ class TestDeleteConfigFile:
 # ---------------------------------------------------------------------------
 # ensure_setup
 # ---------------------------------------------------------------------------
+
 
 class TestEnsureSetup:
     def test_idempotent(self, manager: SSHManager):

--- a/tests/test_backend/test_migrate.py
+++ b/tests/test_backend/test_migrate.py
@@ -19,6 +19,7 @@ from backend.ssh_config import SSHConfigError, SSHConfigManager
 # discover_json_configs
 # ---------------------------------------------------------------------------
 
+
 class TestDiscoverJsonConfigs:
     def test_finds_all_json_files(self, legacy_config_dir: Path):
         results = discover_json_configs(legacy_config_dir)
@@ -59,6 +60,7 @@ class TestDiscoverJsonConfigs:
 # ---------------------------------------------------------------------------
 # convert_json_to_host_entry
 # ---------------------------------------------------------------------------
+
 
 class TestConvertJsonToHostEntry:
     def _base_data(self, **overrides) -> dict:
@@ -156,6 +158,7 @@ class TestConvertJsonToHostEntry:
 # migrate — dry run
 # ---------------------------------------------------------------------------
 
+
 class TestMigrateDryRun:
     def test_dry_run_does_not_write(self, legacy_config_dir: Path, ssh_dir: Path):
         mgr = SSHConfigManager(ssh_dir=ssh_dir)
@@ -172,7 +175,9 @@ class TestMigrateDryRun:
         # vm2 has a password — should produce a warning
         assert "vm2" in result.warnings
 
-    def test_dry_run_no_errors_on_valid_data(self, legacy_config_dir: Path, ssh_dir: Path):
+    def test_dry_run_no_errors_on_valid_data(
+        self, legacy_config_dir: Path, ssh_dir: Path
+    ):
         mgr = SSHConfigManager(ssh_dir=ssh_dir)
         result = migrate(source=legacy_config_dir, config_manager=mgr, dry_run=True)
         assert result.errors == {}
@@ -182,10 +187,11 @@ class TestMigrateDryRun:
 # migrate — live run
 # ---------------------------------------------------------------------------
 
+
 class TestMigrateLive:
     def test_writes_hosts_to_config_file(self, legacy_config_dir: Path, ssh_dir: Path):
         mgr = SSHConfigManager(ssh_dir=ssh_dir)
-        result = migrate(source=legacy_config_dir, config_manager=mgr)
+        migrate(source=legacy_config_dir, config_manager=mgr)
         assert (ssh_dir / "config.d" / "sshaman-migrated").exists()
         hosts = mgr.read_hosts_from_file(ssh_dir / "config.d" / "sshaman-migrated")
         names = {h.name for h in hosts}
@@ -205,9 +211,7 @@ class TestMigrateLive:
         mgr = SSHConfigManager(ssh_dir=ssh_dir)
         migrate(source=legacy_config_dir, config_manager=mgr)
         # Second run with force — should not raise
-        result = migrate(
-            source=legacy_config_dir, config_manager=mgr, force=True
-        )
+        result = migrate(source=legacy_config_dir, config_manager=mgr, force=True)
         assert len(result.migrated) == 3
 
     def test_custom_config_file_name(self, legacy_config_dir: Path, ssh_dir: Path):
@@ -238,9 +242,15 @@ class TestMigrateLive:
         for i in range(2):
             (src / f"srv{i}.json").write_text(
                 json.dumps(
-                    {"alias": "same-name", "host": f"10.0.0.{i+1}", "port": 22,
-                     "user": "u", "identity_file": None, "forward_ports": [],
-                     "start_commands": []}
+                    {
+                        "alias": "same-name",
+                        "host": f"10.0.0.{i + 1}",
+                        "port": 22,
+                        "user": "u",
+                        "identity_file": None,
+                        "forward_ports": [],
+                        "start_commands": [],
+                    }
                 )
             )
         mgr = SSHConfigManager(ssh_dir=ssh_dir)
@@ -254,9 +264,17 @@ class TestMigrateLive:
         src.mkdir()
         # Valid entry
         (src / "good.json").write_text(
-            json.dumps({"alias": "good", "host": "1.2.3.4", "port": 22,
-                        "user": "u", "identity_file": None, "forward_ports": [],
-                        "start_commands": []})
+            json.dumps(
+                {
+                    "alias": "good",
+                    "host": "1.2.3.4",
+                    "port": 22,
+                    "user": "u",
+                    "identity_file": None,
+                    "forward_ports": [],
+                    "start_commands": [],
+                }
+            )
         )
         # Entry missing "alias"
         (src / "bad.json").write_text(json.dumps({"host": "1.2.3.4"}))
@@ -281,13 +299,17 @@ class TestMigrateLive:
         assert result.source_cleanup_reminder != ""
         assert str(legacy_config_dir) in result.source_cleanup_reminder
 
-    def test_no_cleanup_reminder_on_dry_run(self, legacy_config_dir: Path, ssh_dir: Path):
+    def test_no_cleanup_reminder_on_dry_run(
+        self, legacy_config_dir: Path, ssh_dir: Path
+    ):
         """Dry-run migrations must not set the cleanup reminder (nothing was written)."""
         mgr = SSHConfigManager(ssh_dir=ssh_dir)
         result = migrate(source=legacy_config_dir, config_manager=mgr, dry_run=True)
         assert result.source_cleanup_reminder == ""
 
-    def test_force_overwrites_existing_target(self, legacy_config_dir: Path, ssh_dir: Path):
+    def test_force_overwrites_existing_target(
+        self, legacy_config_dir: Path, ssh_dir: Path
+    ):
         """force=True allows re-running migration to an existing target file."""
         mgr = SSHConfigManager(ssh_dir=ssh_dir)
         # First migration creates the target file
@@ -298,9 +320,7 @@ class TestMigrateLive:
 
         # Second migration without force should fail
         with pytest.raises(SSHConfigError, match="already exists"):
-            migrate(
-                source=legacy_config_dir, config_manager=mgr, config_file="target"
-            )
+            migrate(source=legacy_config_dir, config_manager=mgr, config_file="target")
 
         # With force=True it should succeed
         result2 = migrate(

--- a/tests/test_backend/test_ssh_config.py
+++ b/tests/test_backend/test_ssh_config.py
@@ -22,6 +22,7 @@ from backend.ssh_config import (
 # _validate_config_file_name
 # ---------------------------------------------------------------------------
 
+
 class TestValidateConfigFileName:
     def test_valid_name_returns_path(self, tmp_path):
         config_d = tmp_path / "config.d"
@@ -54,6 +55,7 @@ class TestValidateConfigFileName:
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def make_entry(name: str = "srv", hostname: str = "10.0.0.1", **kw) -> HostEntry:
     return HostEntry(name=name, hostname=hostname, **kw)
 
@@ -69,6 +71,7 @@ def permissions(path: Path) -> int:
 # ---------------------------------------------------------------------------
 # ensure_config_d_setup
 # ---------------------------------------------------------------------------
+
 
 class TestEnsureConfigDSetup:
     def test_backup_created_when_config_has_content(self, tmp_path):
@@ -164,6 +167,7 @@ class TestEnsureConfigDSetup:
 # list_config_files
 # ---------------------------------------------------------------------------
 
+
 class TestListConfigFiles:
     def test_returns_sorted_list(self, sample_ssh_dir):
         mgr = SSHConfigManager(ssh_dir=sample_ssh_dir)
@@ -189,6 +193,7 @@ class TestListConfigFiles:
 # ---------------------------------------------------------------------------
 # create_config_file
 # ---------------------------------------------------------------------------
+
 
 class TestCreateConfigFile:
     def test_creates_file(self, ssh_dir):
@@ -232,6 +237,7 @@ class TestCreateConfigFile:
 # delete_config_file
 # ---------------------------------------------------------------------------
 
+
 class TestDeleteConfigFile:
     def test_deletes_existing_file(self, sample_ssh_dir):
         mgr = SSHConfigManager(ssh_dir=sample_ssh_dir)
@@ -257,6 +263,7 @@ class TestDeleteConfigFile:
 # ---------------------------------------------------------------------------
 # read_hosts_from_file
 # ---------------------------------------------------------------------------
+
 
 class TestReadHostsFromFile:
     def test_reads_two_hosts(self, sample_ssh_dir):
@@ -294,6 +301,7 @@ class TestReadHostsFromFile:
 # read_all_hosts
 # ---------------------------------------------------------------------------
 
+
 class TestReadAllHosts:
     def test_reads_all_hosts_across_files(self, sample_ssh_dir):
         mgr = SSHConfigManager(ssh_dir=sample_ssh_dir)
@@ -311,6 +319,7 @@ class TestReadAllHosts:
 # ---------------------------------------------------------------------------
 # write_host
 # ---------------------------------------------------------------------------
+
 
 class TestWriteHost:
     def test_appends_host_to_existing_file(self, sample_ssh_dir):
@@ -347,6 +356,7 @@ class TestWriteHost:
 # remove_host
 # ---------------------------------------------------------------------------
 
+
 class TestRemoveHost:
     def test_removes_host_from_file(self, sample_ssh_dir):
         mgr = SSHConfigManager(ssh_dir=sample_ssh_dir)
@@ -378,6 +388,7 @@ class TestRemoveHost:
 # update_host
 # ---------------------------------------------------------------------------
 
+
 class TestUpdateHost:
     def test_updates_hostname(self, sample_ssh_dir):
         mgr = SSHConfigManager(ssh_dir=sample_ssh_dir)
@@ -403,6 +414,7 @@ class TestUpdateHost:
 # ---------------------------------------------------------------------------
 # _split_into_blocks (parsing helper)
 # ---------------------------------------------------------------------------
+
 
 class TestSplitIntoBlocks:
     def test_skips_wildcard_host(self, ssh_dir):
@@ -434,10 +446,7 @@ class TestSplitIntoBlocks:
         assert blocks[0].comment == "# My host"
 
     def test_multiple_blocks(self, ssh_dir):
-        text = (
-            "Host a\n    HostName 1.1.1.1\n\n"
-            "Host b\n    HostName 2.2.2.2\n\n"
-        )
+        text = "Host a\n    HostName 1.1.1.1\n\nHost b\n    HostName 2.2.2.2\n\n"
         blocks = _split_into_blocks(text, ssh_dir)
         assert len(blocks) == 2
 
@@ -445,6 +454,7 @@ class TestSplitIntoBlocks:
 # ---------------------------------------------------------------------------
 # _remove_block_from_text (internal helper)
 # ---------------------------------------------------------------------------
+
 
 class TestRemoveBlockFromText:
     def test_removes_target_block(self):
@@ -474,6 +484,7 @@ class TestRemoveBlockFromText:
 # _safe_write — exception cleanup
 # ---------------------------------------------------------------------------
 
+
 class TestSafeWriteExceptionHandling:
     """Test that _safe_write cleans up temp files on failure."""
 
@@ -502,6 +513,7 @@ class TestSafeWriteExceptionHandling:
 # ---------------------------------------------------------------------------
 # _split_into_blocks — malformed blocks
 # ---------------------------------------------------------------------------
+
 
 class TestSplitIntoBlocksMalformed:
     """Test that _split_into_blocks gracefully skips malformed Host blocks."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,6 @@ never the real ~/.ssh directory.
 
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -22,14 +21,18 @@ from cli.sshaman_cli import cli
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def invoke(runner: CliRunner, ssh_dir: Path, *args: str, input: str | None = None):
     """Invoke the CLI with --ssh-dir set to the test directory."""
-    return runner.invoke(cli, ["--ssh-dir", str(ssh_dir), *args], input=input, catch_exceptions=False)
+    return runner.invoke(
+        cli, ["--ssh-dir", str(ssh_dir), *args], input=input, catch_exceptions=False
+    )
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def runner() -> CliRunner:
@@ -56,6 +59,7 @@ def populated_ssh_dir(ssh_dir: Path) -> Path:
 # ---------------------------------------------------------------------------
 # list
 # ---------------------------------------------------------------------------
+
 
 class TestListCommand:
     def test_list_shows_all_hosts(self, runner, populated_ssh_dir):
@@ -90,6 +94,7 @@ class TestListCommand:
 # ---------------------------------------------------------------------------
 # show
 # ---------------------------------------------------------------------------
+
 
 class TestShowCommand:
     def test_show_existing_host(self, runner, populated_ssh_dir):
@@ -132,6 +137,7 @@ class TestShowCommand:
 # add
 # ---------------------------------------------------------------------------
 
+
 class TestAddCommand:
     def test_add_host_minimal(self, runner, ssh_dir):
         result = invoke(runner, ssh_dir, "add", "new-host", "--hostname", "192.168.1.1")
@@ -143,13 +149,20 @@ class TestAddCommand:
 
     def test_add_host_all_options(self, runner, ssh_dir):
         result = invoke(
-            runner, ssh_dir,
-            "add", "full-host",
-            "--hostname", "10.10.0.1",
-            "--user", "deploy",
-            "--port", "2222",
-            "--identity-file", "~/.ssh/deploy_key",
-            "--config-file", "custom-file",
+            runner,
+            ssh_dir,
+            "add",
+            "full-host",
+            "--hostname",
+            "10.10.0.1",
+            "--user",
+            "deploy",
+            "--port",
+            "2222",
+            "--identity-file",
+            "~/.ssh/deploy_key",
+            "--config-file",
+            "custom-file",
         )
         assert result.exit_code == 0
         mgr = SSHManager(ssh_dir=ssh_dir)
@@ -159,15 +172,21 @@ class TestAddCommand:
         assert host.port == 2222
 
     def test_add_duplicate_host_fails(self, runner, populated_ssh_dir):
-        result = invoke(runner, populated_ssh_dir, "add", "web-server", "--hostname", "10.0.0.99")
+        result = invoke(
+            runner, populated_ssh_dir, "add", "web-server", "--hostname", "10.0.0.99"
+        )
         assert result.exit_code == 1
 
     def test_add_host_custom_config_file(self, runner, ssh_dir):
         result = invoke(
-            runner, ssh_dir,
-            "add", "work-server",
-            "--hostname", "work.example.com",
-            "--config-file", "10-work-servers",
+            runner,
+            ssh_dir,
+            "add",
+            "work-server",
+            "--hostname",
+            "work.example.com",
+            "--config-file",
+            "10-work-servers",
         )
         assert result.exit_code == 0
         mgr = SSHManager(ssh_dir=ssh_dir)
@@ -181,31 +200,47 @@ class TestAddCommand:
 # edit
 # ---------------------------------------------------------------------------
 
+
 class TestEditCommand:
     def test_edit_hostname(self, runner, populated_ssh_dir):
-        result = invoke(runner, populated_ssh_dir, "edit", "web-server", "--hostname", "10.0.0.99")
+        result = invoke(
+            runner, populated_ssh_dir, "edit", "web-server", "--hostname", "10.0.0.99"
+        )
         assert result.exit_code == 0
         mgr = SSHManager(ssh_dir=populated_ssh_dir)
         assert mgr.get_host("web-server").hostname == "10.0.0.99"
 
     def test_edit_user(self, runner, populated_ssh_dir):
-        result = invoke(runner, populated_ssh_dir, "edit", "web-server", "--user", "root")
+        result = invoke(
+            runner, populated_ssh_dir, "edit", "web-server", "--user", "root"
+        )
         assert result.exit_code == 0
         mgr = SSHManager(ssh_dir=populated_ssh_dir)
         assert mgr.get_host("web-server").user == "root"
 
     def test_edit_port(self, runner, populated_ssh_dir):
-        result = invoke(runner, populated_ssh_dir, "edit", "web-server", "--port", "2222")
+        result = invoke(
+            runner, populated_ssh_dir, "edit", "web-server", "--port", "2222"
+        )
         assert result.exit_code == 0
         mgr = SSHManager(ssh_dir=populated_ssh_dir)
         assert mgr.get_host("web-server").port == 2222
 
     def test_edit_identity_file(self, runner, populated_ssh_dir):
-        result = invoke(runner, populated_ssh_dir, "edit", "web-server", "--identity-file", "~/.ssh/custom")
+        result = invoke(
+            runner,
+            populated_ssh_dir,
+            "edit",
+            "web-server",
+            "--identity-file",
+            "~/.ssh/custom",
+        )
         assert result.exit_code == 0
 
     def test_edit_nonexistent_host(self, runner, populated_ssh_dir):
-        result = invoke(runner, populated_ssh_dir, "edit", "ghost", "--hostname", "10.99.99.99")
+        result = invoke(
+            runner, populated_ssh_dir, "edit", "ghost", "--hostname", "10.99.99.99"
+        )
         assert result.exit_code == 1
 
     def test_edit_no_changes_is_noop(self, runner, populated_ssh_dir):
@@ -217,6 +252,7 @@ class TestEditCommand:
 # ---------------------------------------------------------------------------
 # remove
 # ---------------------------------------------------------------------------
+
 
 class TestRemoveCommand:
     def test_remove_with_yes_flag(self, runner, populated_ssh_dir):
@@ -233,7 +269,8 @@ class TestRemoveCommand:
 
     def test_remove_with_denied_confirmation(self, runner, populated_ssh_dir):
         result = runner.invoke(
-            cli, ["--ssh-dir", str(populated_ssh_dir), "remove", "web-server"],
+            cli,
+            ["--ssh-dir", str(populated_ssh_dir), "remove", "web-server"],
             input="n\n",
             catch_exceptions=False,
         )
@@ -251,6 +288,7 @@ class TestRemoveCommand:
 # connect / sftp (error paths only — os.execvp has pragma no cover)
 # ---------------------------------------------------------------------------
 
+
 class TestConnectCommand:
     def test_connect_nonexistent_host_fails(self, runner, populated_ssh_dir):
         result = invoke(runner, populated_ssh_dir, "connect", "ghost")
@@ -267,6 +305,7 @@ class TestSftpCommand:
 # search
 # ---------------------------------------------------------------------------
 
+
 class TestSearchCommand:
     def test_search_finds_match(self, runner, populated_ssh_dir):
         result = invoke(runner, populated_ssh_dir, "search", "web")
@@ -282,6 +321,7 @@ class TestSearchCommand:
 # ---------------------------------------------------------------------------
 # config subgroup
 # ---------------------------------------------------------------------------
+
 
 class TestConfigList:
     def test_config_list_empty(self, runner, ssh_dir):
@@ -311,7 +351,9 @@ class TestConfigCreate:
 
 class TestConfigDelete:
     def test_config_delete_with_yes(self, runner, populated_ssh_dir):
-        result = invoke(runner, populated_ssh_dir, "config", "delete", "test-hosts", "--yes")
+        result = invoke(
+            runner, populated_ssh_dir, "config", "delete", "test-hosts", "--yes"
+        )
         assert result.exit_code == 0
         mgr = SSHManager(ssh_dir=populated_ssh_dir)
         assert not any(f.name == "test-hosts" for f in mgr.list_config_files())
@@ -321,7 +363,9 @@ class TestConfigDelete:
         assert result.exit_code == 1
 
     def test_config_delete_with_confirmation(self, runner, populated_ssh_dir):
-        result = invoke(runner, populated_ssh_dir, "config", "delete", "test-hosts", input="y\n")
+        result = invoke(
+            runner, populated_ssh_dir, "config", "delete", "test-hosts", input="y\n"
+        )
         assert result.exit_code == 0
 
 
@@ -349,12 +393,15 @@ class TestConfigInit:
 # migrate
 # ---------------------------------------------------------------------------
 
+
 class TestMigrateCommand:
     def test_migrate_dry_run(self, runner, ssh_dir, legacy_config_dir):
         result = invoke(
-            runner, ssh_dir,
+            runner,
+            ssh_dir,
             "migrate",
-            "--source", str(legacy_config_dir),
+            "--source",
+            str(legacy_config_dir),
             "--dry-run",
         )
         assert result.exit_code == 0
@@ -365,10 +412,13 @@ class TestMigrateCommand:
 
     def test_migrate_live(self, runner, ssh_dir, legacy_config_dir):
         result = invoke(
-            runner, ssh_dir,
+            runner,
+            ssh_dir,
             "migrate",
-            "--source", str(legacy_config_dir),
-            "--config-file", "migrated",
+            "--source",
+            str(legacy_config_dir),
+            "--config-file",
+            "migrated",
         )
         assert result.exit_code == 0
         mgr = SSHManager(ssh_dir=ssh_dir)
@@ -379,28 +429,35 @@ class TestMigrateCommand:
         empty_dir = tmp_path / "empty_legacy"
         empty_dir.mkdir()
         result = invoke(
-            runner, ssh_dir,
+            runner,
+            ssh_dir,
             "migrate",
-            "--source", str(empty_dir),
+            "--source",
+            str(empty_dir),
         )
         assert result.exit_code == 0
         assert "Nothing" in result.output
 
     def test_migrate_nonexistent_source(self, runner, ssh_dir, tmp_path):
         result = invoke(
-            runner, ssh_dir,
+            runner,
+            ssh_dir,
             "migrate",
-            "--source", str(tmp_path / "does_not_exist"),
+            "--source",
+            str(tmp_path / "does_not_exist"),
         )
         assert result.exit_code == 0
         assert "Nothing" in result.output
 
     def test_migrate_warns_about_password(self, runner, ssh_dir, legacy_config_dir):
         result = invoke(
-            runner, ssh_dir,
+            runner,
+            ssh_dir,
             "migrate",
-            "--source", str(legacy_config_dir),
-            "--config-file", "migrated2",
+            "--source",
+            str(legacy_config_dir),
+            "--config-file",
+            "migrated2",
         )
         assert result.exit_code == 0
         # Password warning should appear in output
@@ -408,12 +465,37 @@ class TestMigrateCommand:
 
     def test_migrate_force_overwrites(self, runner, ssh_dir, legacy_config_dir):
         # First migration
-        invoke(runner, ssh_dir, "migrate", "--source", str(legacy_config_dir), "--config-file", "mig")
+        invoke(
+            runner,
+            ssh_dir,
+            "migrate",
+            "--source",
+            str(legacy_config_dir),
+            "--config-file",
+            "mig",
+        )
         # Second migration fails without --force
-        result2 = invoke(runner, ssh_dir, "migrate", "--source", str(legacy_config_dir), "--config-file", "mig")
+        result2 = invoke(
+            runner,
+            ssh_dir,
+            "migrate",
+            "--source",
+            str(legacy_config_dir),
+            "--config-file",
+            "mig",
+        )
         assert result2.exit_code == 1
         # With --force it succeeds
-        result3 = invoke(runner, ssh_dir, "migrate", "--source", str(legacy_config_dir), "--config-file", "mig", "--force")
+        result3 = invoke(
+            runner,
+            ssh_dir,
+            "migrate",
+            "--source",
+            str(legacy_config_dir),
+            "--config-file",
+            "mig",
+            "--force",
+        )
         assert result3.exit_code == 0
 
 
@@ -421,14 +503,13 @@ class TestMigrateCommand:
 # No-subcommand → TUI launch (previously uncovered lines 46-58)
 # ---------------------------------------------------------------------------
 
+
 class TestTUILaunch:
     def test_no_subcommand_launches_tui_quit(self, runner, ssh_dir, monkeypatch):
         """Invoking sshaman with no subcommand launches the TUI; user quits."""
         mock_app = MagicMock()
         mock_app.run.return_value = None
-        monkeypatch.setattr(
-            "tui.app.SSHaManApp", lambda **kw: mock_app
-        )
+        monkeypatch.setattr("tui.app.SSHaManApp", lambda **kw: mock_app)
         result = runner.invoke(cli, ["--ssh-dir", str(ssh_dir)], catch_exceptions=False)
         assert result.exit_code == 0
         mock_app.run.assert_called_once()
@@ -437,12 +518,12 @@ class TestTUILaunch:
         """TUI returns an ssh action → os.execvp is called."""
         mock_app = MagicMock()
         mock_app.run.return_value = ("ssh", "web-server")
-        monkeypatch.setattr(
-            "tui.app.SSHaManApp", lambda **kw: mock_app
-        )
+        monkeypatch.setattr("tui.app.SSHaManApp", lambda **kw: mock_app)
 
         execvp_calls: list[tuple] = []
-        monkeypatch.setattr(os, "execvp", lambda cmd, args: execvp_calls.append((cmd, args)))
+        monkeypatch.setattr(
+            os, "execvp", lambda cmd, args: execvp_calls.append((cmd, args))
+        )
 
         result = runner.invoke(
             cli, ["--ssh-dir", str(populated_ssh_dir)], catch_exceptions=False
@@ -451,16 +532,18 @@ class TestTUILaunch:
         assert len(execvp_calls) == 1
         assert execvp_calls[0][0] == "ssh"
 
-    def test_no_subcommand_tui_sftp_action(self, runner, populated_ssh_dir, monkeypatch):
+    def test_no_subcommand_tui_sftp_action(
+        self, runner, populated_ssh_dir, monkeypatch
+    ):
         """TUI returns an sftp action → os.execvp is called with sftp."""
         mock_app = MagicMock()
         mock_app.run.return_value = ("sftp", "web-server")
-        monkeypatch.setattr(
-            "tui.app.SSHaManApp", lambda **kw: mock_app
-        )
+        monkeypatch.setattr("tui.app.SSHaManApp", lambda **kw: mock_app)
 
         execvp_calls: list[tuple] = []
-        monkeypatch.setattr(os, "execvp", lambda cmd, args: execvp_calls.append((cmd, args)))
+        monkeypatch.setattr(
+            os, "execvp", lambda cmd, args: execvp_calls.append((cmd, args))
+        )
 
         result = runner.invoke(
             cli, ["--ssh-dir", str(populated_ssh_dir)], catch_exceptions=False
@@ -473,16 +556,14 @@ class TestTUILaunch:
         """TUI returns an unrecognised action → no execvp, clean exit."""
         mock_app = MagicMock()
         mock_app.run.return_value = ("unknown", "some-host")
-        monkeypatch.setattr(
-            "tui.app.SSHaManApp", lambda **kw: mock_app
-        )
+        monkeypatch.setattr("tui.app.SSHaManApp", lambda **kw: mock_app)
 
         execvp_calls: list[tuple] = []
-        monkeypatch.setattr(os, "execvp", lambda cmd, args: execvp_calls.append((cmd, args)))
-
-        result = runner.invoke(
-            cli, ["--ssh-dir", str(ssh_dir)], catch_exceptions=False
+        monkeypatch.setattr(
+            os, "execvp", lambda cmd, args: execvp_calls.append((cmd, args))
         )
+
+        result = runner.invoke(cli, ["--ssh-dir", str(ssh_dir)], catch_exceptions=False)
         assert result.exit_code == 0
         assert len(execvp_calls) == 0
 
@@ -490,6 +571,7 @@ class TestTUILaunch:
 # ---------------------------------------------------------------------------
 # show — all output fields
 # ---------------------------------------------------------------------------
+
 
 class TestShowAllFields:
     def test_show_local_forwards_and_extras(self, runner, ssh_dir):
@@ -522,6 +604,7 @@ class TestShowAllFields:
 # migrate — error output
 # ---------------------------------------------------------------------------
 
+
 class TestMigrateErrors:
     def test_migrate_shows_conversion_errors(self, runner, ssh_dir, tmp_path):
         """Broken JSON files should produce error output in migration."""
@@ -542,13 +625,24 @@ class TestMigrateErrors:
 # Integration tests — full workflows
 # ---------------------------------------------------------------------------
 
+
 class TestHostLifecycleCLI:
     """End-to-end: add → list → show → edit → remove."""
 
     def test_full_lifecycle(self, runner, ssh_dir):
         # Add
-        r = invoke(runner, ssh_dir, "add", "web1", "--hostname", "10.0.0.1",
-                    "--user", "deploy", "--port", "22")
+        r = invoke(
+            runner,
+            ssh_dir,
+            "add",
+            "web1",
+            "--hostname",
+            "10.0.0.1",
+            "--user",
+            "deploy",
+            "--port",
+            "22",
+        )
         assert r.exit_code == 0
 
         # List
@@ -609,18 +703,33 @@ class TestMigrationLifecycleCLI:
 
     def test_full_lifecycle(self, runner, ssh_dir, legacy_config_dir):
         # Dry run
-        r = invoke(runner, ssh_dir, "migrate", "--source", str(legacy_config_dir),
-                    "--dry-run")
+        r = invoke(
+            runner, ssh_dir, "migrate", "--source", str(legacy_config_dir), "--dry-run"
+        )
         assert "dry run" in r.output.lower()
         assert "Would write" in r.output
 
         # Live run
-        r = invoke(runner, ssh_dir, "migrate", "--source", str(legacy_config_dir),
-                    "--config-file", "mig-live")
+        r = invoke(
+            runner,
+            ssh_dir,
+            "migrate",
+            "--source",
+            str(legacy_config_dir),
+            "--config-file",
+            "mig-live",
+        )
         assert r.exit_code == 0
 
         # Force re-run
-        r = invoke(runner, ssh_dir, "migrate", "--source", str(legacy_config_dir),
-                    "--config-file", "mig-live", "--force")
+        r = invoke(
+            runner,
+            ssh_dir,
+            "migrate",
+            "--source",
+            str(legacy_config_dir),
+            "--config-file",
+            "mig-live",
+            "--force",
+        )
         assert r.exit_code == 0
-

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -5,9 +5,7 @@ Every test uses ``tmp_path`` fixtures — no real ``~/.ssh/`` is touched.
 
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from textual.widgets import Button, DataTable, Input
@@ -52,29 +50,30 @@ class TestAppStartup:
     async def test_app_starts_and_shows_hosts(self, tui_manager: SSHManager) -> None:
         """App should mount and populate the host table with 3 hosts."""
         app = SSHaManApp(manager=tui_manager)
-        async with app.run_test(size=SCREEN_SIZE) as pilot:
+        async with app.run_test(size=SCREEN_SIZE) as _:
             table = app.query_one("#host-table", DataTable)
             assert table.row_count == 3
 
     async def test_app_starts_empty(self, empty_tui_manager: SSHManager) -> None:
         """App with no hosts should show an empty table."""
         app = SSHaManApp(manager=empty_tui_manager)
-        async with app.run_test(size=SCREEN_SIZE) as pilot:
+        async with app.run_test(size=SCREEN_SIZE) as _:
             table = app.query_one("#host-table", DataTable)
             assert table.row_count == 0
 
     async def test_app_has_header_and_footer(self, tui_manager: SSHManager) -> None:
         """App should compose Header and Footer."""
         app = SSHaManApp(manager=tui_manager)
-        async with app.run_test(size=SCREEN_SIZE) as pilot:
+        async with app.run_test(size=SCREEN_SIZE) as _:
             from textual.widgets import Header, Footer
+
             assert len(app.query(Header)) == 1
             assert len(app.query(Footer)) == 1
 
     async def test_app_has_filter_input(self, tui_manager: SSHManager) -> None:
         """App should have a filter input."""
         app = SSHaManApp(manager=tui_manager)
-        async with app.run_test(size=SCREEN_SIZE) as pilot:
+        async with app.run_test(size=SCREEN_SIZE) as _:
             inp = app.query_one("#filter-input", Input)
             assert inp.placeholder == "Filter hosts…"
 
@@ -178,7 +177,9 @@ class TestSSHConnection:
         action, host = app.return_value
         assert action == "sftp"
 
-    async def test_connect_ssh_no_selection(self, empty_tui_manager: SSHManager) -> None:
+    async def test_connect_ssh_no_selection(
+        self, empty_tui_manager: SSHManager
+    ) -> None:
         """SSH connect with no hosts should not crash."""
         app = SSHaManApp(manager=empty_tui_manager)
         async with app.run_test(size=SCREEN_SIZE) as pilot:
@@ -189,7 +190,9 @@ class TestSSHConnection:
         # Should not have exited with a result
         assert app.return_value is None
 
-    async def test_connect_sftp_no_selection(self, empty_tui_manager: SSHManager) -> None:
+    async def test_connect_sftp_no_selection(
+        self, empty_tui_manager: SSHManager
+    ) -> None:
         """SFTP connect with no hosts should not crash."""
         app = SSHaManApp(manager=empty_tui_manager)
         async with app.run_test(size=SCREEN_SIZE) as pilot:
@@ -359,7 +362,9 @@ class TestConfirmScreen:
         results: list[bool] = []
 
         async with app.run_test(size=SCREEN_SIZE) as pilot:
-            await app.push_screen(ConfirmScreen("Delete this?"), callback=results.append)
+            await app.push_screen(
+                ConfirmScreen("Delete this?"), callback=results.append
+            )
             await pilot.pause()
             await pilot.click("#confirm-yes")
             await pilot.pause()
@@ -372,7 +377,9 @@ class TestConfirmScreen:
         results: list[bool] = []
 
         async with app.run_test(size=SCREEN_SIZE) as pilot:
-            await app.push_screen(ConfirmScreen("Delete this?"), callback=results.append)
+            await app.push_screen(
+                ConfirmScreen("Delete this?"), callback=results.append
+            )
             await pilot.pause()
             await pilot.click("#confirm-no")
             await pilot.pause()
@@ -895,7 +902,7 @@ class TestGetSelectedHostName:
     async def test_returns_none_when_empty(self, empty_tui_manager: SSHManager) -> None:
         """Should return None when table is empty."""
         app = SSHaManApp(manager=empty_tui_manager)
-        async with app.run_test(size=SCREEN_SIZE) as pilot:
+        async with app.run_test(size=SCREEN_SIZE) as _:
             result = app._get_selected_host_name()
             assert result is None
 
@@ -1038,7 +1045,7 @@ class TestConfigFilesNewFileCallback:
             await app.push_screen(screen)
             await pilot.pause()
 
-            # Create it first  
+            # Create it first
             screen._on_new_file("60-dup-test")
             await pilot.pause()
 
@@ -1090,7 +1097,9 @@ class TestHostFormWithMultipleConfigFiles:
 
             app.screen.query_one("#input-name", Input).value = "id-host"
             app.screen.query_one("#input-hostname", Input).value = "1.2.3.4"
-            app.screen.query_one("#input-identity-file", Input).value = "~/.ssh/id_ed25519"
+            app.screen.query_one(
+                "#input-identity-file", Input
+            ).value = "~/.ssh/id_ed25519"
 
             app.screen.query_one("#btn-save", Button).press()
             await pilot.pause()
@@ -1113,7 +1122,7 @@ class TestGetSelectedHostNameException:
     ) -> None:
         """If coordinate_to_cell_key raises, return None instead of crashing."""
         app = SSHaManApp(manager=tui_manager)
-        async with app.run_test(size=SCREEN_SIZE) as pilot:
+        async with app.run_test(size=SCREEN_SIZE) as _:
             table = app.query_one("#host-table", DataTable)
             original = table.coordinate_to_cell_key
 
@@ -1130,9 +1139,7 @@ class TestGetSelectedHostNameException:
 class TestRowSelectedHostNotFound:
     """Cover on_data_table_row_selected when host is None (line 135)."""
 
-    async def test_row_selected_host_deleted(
-        self, tui_manager: SSHManager
-    ) -> None:
+    async def test_row_selected_host_deleted(self, tui_manager: SSHManager) -> None:
         """If the host was deleted between display and selection, no crash."""
         app = SSHaManApp(manager=tui_manager)
         async with app.run_test(size=SCREEN_SIZE) as pilot:
@@ -1146,9 +1153,7 @@ class TestRowSelectedHostNotFound:
             await pilot.pause()
             tui_manager.get_host = original_get_host
             # Should NOT have pushed a detail screen
-            assert not any(
-                isinstance(s, HostDetailScreen) for s in app.screen_stack
-            )
+            assert not any(isinstance(s, HostDetailScreen) for s in app.screen_stack)
 
 
 class TestDetailResultHostNameNone:
@@ -1186,9 +1191,7 @@ class TestEditHostGetHostNone:
             await pilot.pause()
             tui_manager.get_host = original_get_host
             # No form should appear
-            assert not any(
-                isinstance(s, HostFormScreen) for s in app.screen_stack
-            )
+            assert not any(isinstance(s, HostFormScreen) for s in app.screen_stack)
 
 
 class TestDeleteConfirmedHostGone:
@@ -1248,9 +1251,7 @@ class TestAddHostResultNoConfigAttr:
 class TestNewConfigFileRejectsInvalidName:
     """Cover NewConfigFileScreen regex rejection (lines 168-172)."""
 
-    async def test_name_with_spaces_rejected(
-        self, tui_manager: SSHManager
-    ) -> None:
+    async def test_name_with_spaces_rejected(self, tui_manager: SSHManager) -> None:
         """Names with spaces should be rejected."""
         app = SSHaManApp(manager=tui_manager)
         results: list[str | None] = []
@@ -1308,8 +1309,6 @@ class TestHostFormValidationError:
             app.screen.query_one("#input-hostname", Input).value = "example.com"
 
             # Monkeypatch HostEntry to raise on construction
-            original_init = HostEntry.__init__
-
             def broken_init(self, **kwargs):
                 raise ValueError("synthetic validation error")
 
@@ -1340,9 +1339,7 @@ class TestHostFormSelectChangedBranch:
 
             original = screen._selected_config_file
             # Simulate a select-changed event from a different select widget
-            fake_select = Select(
-                [("x", "x")], id="other-select"
-            )
+            fake_select = Select([("x", "x")], id="other-select")
             event = Select.Changed(fake_select, "x")
             screen.on_select_changed(event)
             await pilot.pause()
@@ -1354,9 +1351,7 @@ class TestHostFormSelectChangedBranch:
 class TestConfigFilesButtonFallthrough:
     """Cover ConfigFilesScreen on_button_pressed fallthrough (line 92->exit)."""
 
-    async def test_unknown_button_is_noop(
-        self, tui_manager: SSHManager
-    ) -> None:
+    async def test_unknown_button_is_noop(self, tui_manager: SSHManager) -> None:
         """A button with an unrecognized id should be a no-op."""
         app = SSHaManApp(manager=tui_manager)
 
@@ -1379,9 +1374,7 @@ class TestConfigFilesButtonFallthrough:
 class TestNewConfigFileButtonFallthrough:
     """Cover NewConfigFileScreen on_button_pressed fallthrough (line 161->exit)."""
 
-    async def test_unknown_button_is_noop(
-        self, tui_manager: SSHManager
-    ) -> None:
+    async def test_unknown_button_is_noop(self, tui_manager: SSHManager) -> None:
         """A button with an unrecognized id in NewConfigFileScreen is a no-op."""
         app = SSHaManApp(manager=tui_manager)
         results: list[str | None] = []

--- a/tui/screens/config_files.py
+++ b/tui/screens/config_files.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from pathlib import Path
 
 from textual.app import ComposeResult
 from textual.containers import Vertical
@@ -80,7 +79,8 @@ class ConfigFilesScreen(ModalScreen[None]):
 
         for path in files:
             count = sum(
-                1 for h in all_hosts
+                1
+                for h in all_hosts
                 if h.source_file and h.source_file.name == path.name
             )
             table.add_row(path.name, str(count), key=path.name)

--- a/tui/screens/host_detail.py
+++ b/tui/screens/host_detail.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Button, Label, Static
+from textual.widgets import Button, Static
 
 from backend.host_entry import HostEntry
 

--- a/tui/screens/host_form.py
+++ b/tui/screens/host_form.py
@@ -81,7 +81,11 @@ class HostFormScreen(ModalScreen[HostEntry | None]):
         """Build the form."""
         h = self._host
         with Vertical():
-            yield Label("[bold]Add Host[/bold]" if h is None else f"[bold]Edit Host: {h.name}[/bold]")
+            yield Label(
+                "[bold]Add Host[/bold]"
+                if h is None
+                else f"[bold]Edit Host: {h.name}[/bold]"
+            )
 
             yield Label("Host alias:")
             yield Input(


### PR DESCRIPTION
Add scripts/lint.sh to run ruff (check/format) and document linting in .github/copilot-instructions.md; update VSCode settings to recognise ruff. Update pyproject.toml package discovery. Apply code formatting and minor non-functional cleanups across backend, cli, tui and tests (reflow long lines, normalize raises/expressions, small whitespace/line-break changes). Tests updated to match formatting changes. No behavioral changes intended—mostly style and packaging improvements.